### PR TITLE
Add ARM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jsdom": "^9.8.3",
     "json-loader": "^0.5.4",
     "mocha": "^3.2.0",
-    "node-sass": "^3.13.0",
+    "node-sass": "^4.5.0",
     "nyc": "^10.0.0",
     "postcss-loader": "^1.1.1",
     "precss": "^1.4.0",


### PR DESCRIPTION
After `npm install`ing on my ARM device,
When I run
```
npm start
```
I get an error:
```
ERROR in Node Sass does not yet support your current environment: Linux Unsupported architecture (arm) with Node.js 7.x
For more information on which environments are supported please see:
https://github.com/sass/node-sass/releases/tag/v3.13.1
 @ ./src/app/style/index.scss 4:14-170 13:2-17:4 14:20-176
webpack: Failed to compile.
```
I updated `node-sass` to the latest version and it works fine on my ARM device now!

Would you consider upgrading `node-sass`?